### PR TITLE
Feature/groups screen feature with UI and search fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,7 @@ android/app/libs
 android/keystores/debug.keystore
 
 # Yarn
-.yarn/*
 !.yarn/patches
-!.yarn/plugins
-!.yarn/releases
 !.yarn/sdks
 !.yarn/versions
 

--- a/src/components/AmityCommunitySearchResultComponent/AmityCommunitySearchResultComponent.styles.ts
+++ b/src/components/AmityCommunitySearchResultComponent/AmityCommunitySearchResultComponent.styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  noResultContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 20,
+  },
+  noResultText: {
+    fontSize: 16,
+    color: '#8E8E93',
+    textAlign: 'center',
+  },
+});

--- a/src/components/AmityCommunitySearchResultComponent/AmityCommunitySearchResultComponent.tsx
+++ b/src/components/AmityCommunitySearchResultComponent/AmityCommunitySearchResultComponent.tsx
@@ -1,14 +1,16 @@
 import React, { FC, memo } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { FlatList, Text, View } from 'react-native';
 import { ComponentID, PageID, TabName } from '../../enum';
 import { useAmityComponent } from '../../hooks/useUiKitReference';
 import SearchResultItem from '../SearchResultItem/SearchResultItem';
+import { styles } from './AmityCommunitySearchResultComponent.styles';
 
 type AmityCommunitySearchResultComponentType = {
   pageId?: PageID;
   searchResult: Amity.Community[] & Amity.User[];
   searchType: TabName;
   onNextPage: () => void;
+  isLoading: boolean;
 };
 
 const AmityCommunitySearchResultComponent: FC<
@@ -18,14 +20,10 @@ const AmityCommunitySearchResultComponent: FC<
   searchType,
   onNextPage,
   pageId = PageID.WildCardPage,
+  isLoading,
 }) => {
   const componentId = ComponentID.community_search_result;
   const { isExcluded } = useAmityComponent({ pageId, componentId });
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-    },
-  });
 
   const renderSearchResultItem = ({
     item,
@@ -43,7 +41,16 @@ const AmityCommunitySearchResultComponent: FC<
   };
 
   if (isExcluded) return null;
-  if (!searchResult?.length) return null;
+  if (!searchResult?.length && !isLoading)
+    return (
+      <View style={styles.noResultContainer}>
+        <Text style={styles.noResultText}>
+          No {searchType.toLowerCase()} found matching your search
+        </Text>
+      </View>
+    );
+
+  console.log('searchResult', searchResult);
 
   return (
     <View style={styles.container}>
@@ -54,6 +61,7 @@ const AmityCommunitySearchResultComponent: FC<
         onEndReached={() => {
           onNextPage && onNextPage();
         }}
+        showsVerticalScrollIndicator={false}
       />
     </View>
   );

--- a/src/components/AmityGlobalFeedComponent/AmityGlobalFeedComponent.tsx
+++ b/src/components/AmityGlobalFeedComponent/AmityGlobalFeedComponent.tsx
@@ -154,6 +154,7 @@ const AmityGlobalFeedComponent: FC<AmityGlobalFeedComponentType> = ({
       viewabilityConfig={{ viewAreaCoveragePercentThreshold: 60 }}
       onViewableItemsChanged={handleViewChange}
       extraData={postList}
+      showsVerticalScrollIndicator={false}
     />
   ) : (
     <View style={styles.feedWrap}>

--- a/src/enum/AmityUiKitRoutes.ts
+++ b/src/enum/AmityUiKitRoutes.ts
@@ -28,4 +28,5 @@ export enum AmityUiKitRoutes {
   EditPost = 'EditPost',
   FollowerList = 'FollowerList',
   UserPendingRequest = 'UserPendingRequest',
+  AllCommunitiesListing = 'AllCommunitiesListing',
 }

--- a/src/hooks/useAmityGlobalSearchViewModel.ts
+++ b/src/hooks/useAmityGlobalSearchViewModel.ts
@@ -17,21 +17,26 @@ export const useAmityGlobalSearchViewModel = (
   );
 
   const [searchResult, setSearchResult] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (searchValue?.length < 3) return setSearchResult(null);
     if (searchType === TabName.Communities) {
       setSearchResult(null);
+      setIsLoading(true);
       const unsubscribeCommunity = CommunityRepository.getCommunities(
         {
           displayName: searchValue,
-          membership: 'notMember',
+          membership: 'all',
           limit: 20,
           sortBy: 'displayName',
         },
         ({ error, loading, data, hasNextPage, onNextPage }) => {
-          if (error) return setSearchResult(null);
+          if (error) {
+            setIsLoading(false);
+            return setSearchResult(null);
+          }
           if (!loading) {
+            setIsLoading(false);
             setOnNextCommunityPage(() => (hasNextPage ? onNextPage : null));
             setSearchResult(data);
           }
@@ -40,11 +45,16 @@ export const useAmityGlobalSearchViewModel = (
       return () => unsubscribeCommunity();
     } else if (searchType === TabName.Users) {
       setSearchResult(null);
+      setIsLoading(true);
       const unsubscribeUser = UserRepository.getUsers(
         { displayName: searchValue, limit: 20, sortBy: 'displayName' },
         ({ error, loading, data, hasNextPage, onNextPage }) => {
-          if (error) return setSearchResult(null);
+          if (error) {
+            setIsLoading(false);
+            return setSearchResult(null);
+          }
           if (!loading) {
+            setIsLoading(false);
             setOnNextUserPage(() => (hasNextPage ? onNextPage : null));
             setSearchResult(data);
           }
@@ -53,8 +63,9 @@ export const useAmityGlobalSearchViewModel = (
       return () => unsubscribeUser();
     } else {
       setSearchResult(null);
+      setIsLoading(false);
     }
   }, [searchType, searchValue]);
 
-  return { searchResult, onNextCommunityPage, onNextUserPage };
+  return { searchResult, onNextCommunityPage, onNextUserPage, isLoading };
 };

--- a/src/routes/RouteParamList.tsx
+++ b/src/routes/RouteParamList.tsx
@@ -70,4 +70,5 @@ export type RootStackParamList = {
   MyUserProfile: undefined;
   PreloadCommunityHome: undefined;
   MyCommunity: undefined;
+  AllCommunitiesListing: undefined;
 };

--- a/src/routes/SocialNavigator.tsx
+++ b/src/routes/SocialNavigator.tsx
@@ -8,6 +8,7 @@ import useAuth from '../hooks/useAuth';
 import CategoryList from '../screens/CategorytList';
 import CommunityHome from '../screens/CommunityHome/index';
 import CommunityList from '../screens/CommunityList';
+import AllCommunitiesListing from '../screens/AllCommunitiesListing';
 import CommunityMemberDetail from '../screens/CommunityMemberDetail/CommunityMemberDetail';
 import { CommunitySetting } from '../screens/CommunitySetting/index';
 import Explore from '../screens/Explore';
@@ -204,6 +205,10 @@ export default function SocialNavigator({
             <Stack.Screen
               name={AmityUiKitRoutes.CommunityList}
               component={CommunityList}
+            />
+            <Stack.Screen
+              name={AmityUiKitRoutes.AllCommunitiesListing}
+              component={AllCommunitiesListing}
             />
             <Stack.Screen
               name={AmityUiKitRoutes.AmitySocialGlobalSearchPage}

--- a/src/screens/AllCommunitiesListing/blocks/CommunityItem.tsx
+++ b/src/screens/AllCommunitiesListing/blocks/CommunityItem.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { SvgXml } from 'react-native-svg';
+import { communityIcon } from '../../../svg/svg-xml-list';
+import useAuth from '../../../hooks/useAuth';
+import { useStyles } from './communityItem.styles';
+
+const CommunityItem = ({
+  item,
+  onPressCommunity,
+}: {
+  item: Amity.Community & { category?: string };
+  onPressCommunity: (community: {
+    communityId: string;
+    communityName: string;
+  }) => void;
+}) => {
+  const { apiRegion } = useAuth();
+  const styles = useStyles();
+
+  const avatarFileURL = (fileId: string) => {
+    return `https://api.${apiRegion}.amity.co/api/v3/files/${fileId}/download?size=medium`;
+  };
+
+  return (
+    <TouchableOpacity
+      style={styles.rowContainer}
+      onPress={() =>
+        onPressCommunity({
+          communityId: item.communityId,
+          communityName: item.displayName,
+        })
+      }
+    >
+      {item?.avatarFileId ? (
+        <Image
+          style={styles.avatar}
+          source={{
+            uri: item.avatarFileId && avatarFileURL(item.avatarFileId!),
+          }}
+        />
+      ) : (
+        <View style={styles.avatar}>
+          <SvgXml xml={communityIcon} />
+        </View>
+      )}
+
+      <View style={styles.textContainer}>
+        <Text style={styles.communityName}>{item.displayName}</Text>
+        {item?.category && (
+          <Text
+            style={styles.category}
+            testID="community_search_result/community_category_name"
+            accessibilityLabel="community_search_result/community_category_name"
+          >
+            {item.category}
+          </Text>
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default CommunityItem;

--- a/src/screens/AllCommunitiesListing/blocks/communityItem.styles.ts
+++ b/src/screens/AllCommunitiesListing/blocks/communityItem.styles.ts
@@ -1,0 +1,48 @@
+import { StyleSheet } from 'react-native';
+import type { MyMD3Theme } from '../../../providers/amity-ui-kit-provider';
+import { useTheme } from 'react-native-paper';
+
+export const useStyles = () => {
+  const theme = useTheme() as MyMD3Theme;
+  const styles = StyleSheet.create({
+    avatar: {
+      width: 60,
+      height: 60,
+      borderRadius: 60 / 2,
+      marginBottom: 10,
+      backgroundColor: '#D9E5FC',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    rowContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 10,
+    },
+    communityName: {
+      marginLeft: 4,
+      marginBottom: 4,
+      fontSize: 15,
+      fontWeight: 'bold',
+      color: theme.colors.base,
+    },
+    category: {
+      marginVertical: 2,
+      alignSelf: 'flex-start',
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      backgroundColor: theme.colors.baseShade4,
+      color: theme.colors.base,
+      borderRadius: 12,
+      overflow: 'hidden',
+      marginHorizontal: 2,
+      fontSize: 12,
+    },
+    textContainer: {
+      flex: 1,
+      marginLeft: 10,
+    },
+  });
+
+  return styles;
+};

--- a/src/screens/AllCommunitiesListing/index.tsx
+++ b/src/screens/AllCommunitiesListing/index.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { CommunityRepository } from '@amityco/ts-sdk-react-native';
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useLayoutEffect,
+} from 'react';
+import { FlatList, View, ActivityIndicator } from 'react-native';
+import CloseButton from '../../components/BackButton';
+import { useStyles } from './styles';
+import CommunityItem from './blocks/CommunityItem';
+import { useCategory } from '../../hooks';
+
+type CommunityWithCategory = Amity.Community & {
+  category?: string; // Using optional (?) since it might not always be present
+};
+
+export default function AllCommunitiesListing({ navigation }: any) {
+  const [communities, setCommunities] = useState<CommunityWithCategory[]>([]);
+  const [paginateLoading, setPaginateLoading] = useState(false);
+  const [hasNextPageState, setHasNextPageState] = useState(false);
+  const { getCategory } = useCategory();
+
+  const styles = useStyles();
+  const onNextPageRef = useRef<(() => void) | null>(null);
+  const isFetchingRef = useRef(false);
+  const onEndReachedCalledDuringMomentumRef = useRef(true);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: CloseButton,
+      title: 'Groups',
+    });
+  }, [navigation]);
+
+  useEffect(() => {
+    const loadCommunities = async () => {
+      setPaginateLoading(true);
+      try {
+        const unsubscribe = CommunityRepository.getCommunities(
+          { limit: 10 },
+          async ({ data, onNextPage, hasNextPage, loading }) => {
+            if (!loading) {
+              // Only map new communities that aren't already in the state
+              const newCommunitiesWithCategories = await Promise.all(
+                data.map(async (community) => {
+                  let category = '';
+                  if (community.categoryIds?.[0]) {
+                    const categoryData = await getCategory(
+                      community.categoryIds[0]
+                    );
+                    category = categoryData?.name ?? '';
+                  }
+                  return { ...community, category };
+                })
+              );
+
+              setCommunities((prevCommunities) => {
+                const uniqueCommunities = Array.from(
+                  new Set(
+                    [...prevCommunities, ...newCommunitiesWithCategories].map(
+                      (c) => c.communityId
+                    )
+                  )
+                ).map(
+                  (id) =>
+                    [...prevCommunities, ...newCommunitiesWithCategories].find(
+                      (c) => c.communityId === id
+                    )!
+                );
+                return uniqueCommunities;
+              });
+              setHasNextPageState(hasNextPage);
+              onNextPageRef.current = onNextPage;
+              isFetchingRef.current = false;
+              setPaginateLoading(false);
+            }
+          }
+        );
+        return () => unsubscribe();
+      } catch (error) {
+        console.error('Failed to load communities:', error);
+        isFetchingRef.current = false;
+        setPaginateLoading(false);
+      }
+    };
+
+    loadCommunities();
+  }, [getCategory]);
+
+  const onPressCommunity = useCallback(
+    ({
+      communityId,
+      communityName,
+    }: {
+      communityId: string;
+      communityName: string;
+    }) => {
+      navigation.navigate('CommunityHome', { communityId, communityName });
+    },
+    [navigation]
+  );
+
+  const renderFooter = () => {
+    if (!paginateLoading) return null;
+    return (
+      <View style={styles.LoadingIndicator}>
+        <ActivityIndicator size="small" />
+      </View>
+    );
+  };
+
+  const handleEndReached = useCallback(() => {
+    if (
+      !isFetchingRef.current &&
+      hasNextPageState &&
+      onEndReachedCalledDuringMomentumRef.current
+    ) {
+      isFetchingRef.current = true;
+      onEndReachedCalledDuringMomentumRef.current = false;
+      setPaginateLoading(true);
+      onNextPageRef.current && onNextPageRef.current();
+    }
+  }, [hasNextPageState]);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={communities}
+        renderItem={({ item }) => (
+          <CommunityItem item={item} onPressCommunity={onPressCommunity} />
+        )}
+        keyExtractor={(item) => item.communityId.toString()}
+        ListFooterComponent={renderFooter}
+        onEndReached={handleEndReached}
+        onMomentumScrollBegin={() => {
+          onEndReachedCalledDuringMomentumRef.current = true;
+        }}
+        onEndReachedThreshold={0.8}
+        contentContainerStyle={styles.listContentContainer}
+        showsVerticalScrollIndicator={false}
+      />
+    </View>
+  );
+}

--- a/src/screens/AllCommunitiesListing/styles.ts
+++ b/src/screens/AllCommunitiesListing/styles.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+import type { MyMD3Theme } from '../../providers/amity-ui-kit-provider';
+
+export const useStyles = () => {
+  const theme = useTheme() as MyMD3Theme;
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    LoadingIndicator: {
+      paddingVertical: 20,
+    },
+    listContentContainer: {
+      paddingBottom: 60,
+    },
+  });
+
+  return styles;
+};

--- a/src/screens/AmitySocialGlobalSearchPage/AmitySocialGlobalSearchPage.tsx
+++ b/src/screens/AmitySocialGlobalSearchPage/AmitySocialGlobalSearchPage.tsx
@@ -17,11 +17,12 @@ const AmitySocialGlobalSearchPage = () => {
   const styles = useStyles(themeStyles);
   const [searchValue, setSearchValue] = useState('');
   const [searchType, setSearchType] = useState(TabName.Communities);
-  const { searchResult, onNextCommunityPage, onNextUserPage } =
+  const { searchResult, onNextCommunityPage, onNextUserPage, isLoading } =
     useAmityGlobalSearchViewModel(searchValue, searchType);
   const onNextPage =
     searchType === TabName.Communities ? onNextCommunityPage : onNextUserPage;
   if (isExcluded) return null;
+
   return (
     <SafeAreaView style={styles.container}>
       <AmityTopSearchBarComponent setSearchValue={setSearchValue} />
@@ -36,6 +37,7 @@ const AmitySocialGlobalSearchPage = () => {
           searchType={searchType}
           searchResult={searchResult}
           onNextPage={onNextPage}
+          isLoading={isLoading}
         />
       ) : (
         <SearchPlaceholderLanding themeStyles={themeStyles} />

--- a/src/screens/CategorytList/index.tsx
+++ b/src/screens/CategorytList/index.tsx
@@ -118,7 +118,6 @@ export default function CategoryList({ navigation }: any) {
         renderItem={renderCategory}
         keyExtractor={(item) => item.categoryId.toString()}
         ListFooterComponent={renderFooter}
-        // onEndReached={handleEndReached}
         onEndReached={handleEndReached}
         onMomentumScrollBegin={() =>
           (onEndReachedCalledDuringMomentumRef.current = false)

--- a/src/screens/CommunityHome/index.tsx
+++ b/src/screens/CommunityHome/index.tsx
@@ -27,12 +27,7 @@ import CustomTabV4 from '../../components/CustomTabV4';
 import useAuth from '../../hooks/useAuth';
 import Feed from '../Feed';
 import { useStyles } from './styles';
-
-import {
-  StackActions,
-  useFocusEffect,
-  useNavigation,
-} from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from 'react-native-paper';
 import { useDispatch } from 'react-redux';
@@ -327,7 +322,7 @@ export default function CommunityHome({ route }: any) {
         <RoundButton
           isTransparent={isStickyHeaderVisible}
           onPress={() => {
-            navigation.dispatch(StackActions.pop(2));
+            navigation.goBack();
           }}
         >
           <SvgXml xml={screenBackIcon()} />

--- a/src/screens/Explore/index.tsx
+++ b/src/screens/Explore/index.tsx
@@ -48,6 +48,7 @@ export default function Explore() {
       }
     );
   };
+
   const loadCategories = async () => {
     CategoryRepository.getCategories(
       { sortBy: 'name', limit: 8 },
@@ -170,9 +171,16 @@ export default function Explore() {
         </ScrollView>
       </View>
 
-      {/* Trending Now Section  */}
+      {/* Groups Section  */}
       <View style={styles.trendingContainer}>
-        <Text style={styles.title}>Trending now</Text>
+        <View style={styles.groupsTitleContainer}>
+          <Text style={styles.groupTitle}>Groups</Text>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('AllCommunitiesListing')}
+          >
+            <Text style={styles.viewAllText}>View all</Text>
+          </TouchableOpacity>
+        </View>
         <View>
           {trendingCommunityList.map((community) => (
             <TouchableOpacity
@@ -201,18 +209,13 @@ export default function Explore() {
               )}
 
               <View style={styles.trendingTextContainer}>
-                {/* <Text style={styles.number}>{index + 1}</Text> */}
                 <View style={styles.memberContainer}>
-                  <View style={styles.memberTextContainer}>
-                    <View style={styles.memberTextWrapper}>
-                      <Text numberOfLines={1} style={styles.memberText}>
-                        {community.displayName}
-                      </Text>
-                    </View>
-                    {community.isOfficial && (
-                      <SvgXml width={24} height={24} xml={verifiedIcon()} />
-                    )}
-                  </View>
+                  <Text numberOfLines={1} style={styles.memberText}>
+                    {community.displayName}
+                  </Text>
+                  {community.isOfficial && (
+                    <SvgXml width={24} height={24} xml={verifiedIcon()} />
+                  )}
                 </View>
               </View>
             </TouchableOpacity>

--- a/src/screens/Explore/styles.ts
+++ b/src/screens/Explore/styles.ts
@@ -8,7 +8,7 @@ export const useStyles = () => {
 
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: theme.colors.baseShade4,
+      backgroundColor: theme.colors.baseDivider,
     },
     recommendContainer: {
       backgroundColor: theme.colors.baseDivider,
@@ -33,6 +33,7 @@ export const useStyles = () => {
       paddingStart: amityUIKitTokens.spacing.m1,
       flexDirection: 'row',
       alignItems: 'center',
+      flex: 1,
     },
     card: {
       width: 268,
@@ -97,19 +98,16 @@ export const useStyles = () => {
     },
     memberContainer: {
       alignItems: 'flex-start',
-    },
-    memberTextContainer: {
-      alignItems: 'flex-start',
       flexDirection: 'row',
+      flex: 1,
     },
     memberText: {
       fontSize: 18,
       fontWeight: '600',
       marginRight: 4,
       color: theme.colors.base,
+      maxWidth: '80%',
     },
-    memberTextWrapper: { maxWidth: '90%' },
-
     memberCount: {
       fontSize: 13,
       fontWeight: '400',
@@ -120,7 +118,7 @@ export const useStyles = () => {
       paddingTop: 20,
       paddingHorizontal: amityUIKitTokens.spacing.m1,
       paddingBottom: 120,
-      backgroundColor: theme.colors.background,
+      backgroundColor: theme.colors.baseDivider,
     },
     titleContainer: {
       flexDirection: 'row',
@@ -129,7 +127,7 @@ export const useStyles = () => {
       marginBottom: 10,
     },
     titleText: {
-      fontSize: 18,
+      fontSize: 20,
       fontWeight: 'bold',
       marginBottom: 10,
       color: theme.colors.base,
@@ -181,7 +179,7 @@ export const useStyles = () => {
       flexDirection: 'row',
     },
     categoryName: {
-      fontSize: 12,
+      fontSize: 14,
       lineHeight: 24,
       fontWeight: '600',
       color: theme.colors.base,
@@ -196,6 +194,22 @@ export const useStyles = () => {
     },
     recommendedTitleContainer: {
       paddingHorizontal: amityUIKitTokens.spacing.m1,
+    },
+    groupsTitleContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 20,
+    },
+    viewAllText: {
+      fontWeight: 'bold',
+      fontSize: 16,
+      color: '#118CF7',
+    },
+    groupTitle: {
+      fontWeight: 'bold',
+      fontSize: 20,
+      color: theme.colors.base,
     },
   });
   return styles;


### PR DESCRIPTION
- Search fix to show all groups when searching
- Search fix to show search results when entering one letter, not having to wait for 3 letters to be typed (for users it's a backend limitation where social+ is pushing back for so it's still not done)
- UI fixes to remove vertical scroll indicator
- UI fixes to remove different background color when scrolling
- UX Enhancements (adding loaders and no search results found text)
- New screen for groups listing
- Replaced 'Trending now' with 'Groups' while keeping them as trending
- View all button navigates to groups listing screen with pagination.
- Categories added to group listing screen